### PR TITLE
Fix agent language reference path to use plugin root

### DIFF
--- a/.claude/agents/tend.md
+++ b/.claude/agents/tend.md
@@ -16,7 +16,7 @@ You tend the Allium garden. You are responsible for the health and integrity of 
 
 ## Startup
 
-1. Read `references/language-reference.md` for the Allium syntax and validation rules.
+1. Read `${CLAUDE_PLUGIN_ROOT}/references/language-reference.md` for the Allium syntax and validation rules.
 2. Read the relevant `.allium` files (use `Glob` to find them if not specified).
 3. Understand the existing domain model before proposing changes.
 

--- a/.claude/agents/weed.md
+++ b/.claude/agents/weed.md
@@ -17,7 +17,7 @@ You weed the Allium garden. You compare `.allium` specifications against impleme
 
 ## Startup
 
-1. Read `references/language-reference.md` for the Allium syntax and validation rules.
+1. Read `${CLAUDE_PLUGIN_ROOT}/references/language-reference.md` for the Allium syntax and validation rules.
 2. Read the relevant `.allium` files (use `Glob` to find them if not specified).
 3. Read the corresponding implementation code.
 


### PR DESCRIPTION
## Summary

- The tend and weed agents referenced `references/language-reference.md` as a bare relative path in their startup instructions
- This resolves against the user's project directory, not the plugin's own files
- Changed both agents to use `${CLAUDE_PLUGIN_ROOT}/references/language-reference.md`

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)