### PR TITLE
security: restrict Bash tool to allium commands only

### DIFF
--- a/.claude/agents/tend.md
+++ b/.claude/agents/tend.md
@@ -8,7 +8,7 @@ tools:
   - Grep
   - Edit
   - Write
-  - Bash
+  - Bash(allium *)
 ---
 
 # Tend

--- a/.claude/agents/weed.md
+++ b/.claude/agents/weed.md
@@ -8,7 +8,7 @@ tools:
   - Grep
   - Edit
   - Write
-  - Bash
+  - Bash(allium *)
 ---
 
 # Weed


### PR DESCRIPTION
## Summary

- Replace unrestricted `Bash` with `Bash(allium *)` in both `tend.md` and `weed.md` agent definitions
- Both agents only need to invoke `allium check` via the CLI — no other shell commands are required (file reading uses `Read`/`Glob`/`Grep` tools)
- Applies the principle of least privilege to agent tool declarations

## Why

The `tend` and `weed` agents declare an unrestricted `Bash` tool in their YAML frontmatter, granting them full shell access. However, the only bash command either agent needs is `allium check <file>` (referenced in each agent's Startup section). All other file operations use dedicated tools (`Read`, `Glob`, `Grep`, `Edit`, `Write`).

An adversary could craft a malicious `.allium` file whose content manipulates the agent's instructions (prompt injection). With unrestricted `Bash`, this could escalate to arbitrary shell execution on the host. Restricting to `Bash(allium *)` limits the blast radius — even if the agent is manipulated, it can only invoke the `allium` CLI.

## Changes

| File | Before | After |
|------|--------|-------|
| `.claude/agents/tend.md` | `- Bash` | `- Bash(allium *)` |
| `.claude/agents/weed.md` | `- Bash` | `- Bash(allium *)` |

## Verification

- `allium check <file>` is still permitted (matched by `allium *`)
- No unrestricted `Bash` remains in either agent definition
- All other tools (`Read`, `Glob`, `Grep`, `Edit`, `Write`) are unchanged