### PR TITLE
security: add project root boundary check in allium hook

### DIFF
--- a/.claude/hooks/allium-check.mjs
+++ b/.claude/hooks/allium-check.mjs
@@ -1,5 +1,6 @@
 import { execFileSync } from "child_process";
 import { extname } from "path";
+import path from "path";
 
 let data = "";
 for await (const chunk of process.stdin) {
@@ -13,8 +14,14 @@ if (!filePath || extname(filePath) !== ".allium") {
   process.exit(0);
 }
 
+const projectRoot = path.resolve(process.env.CLAUDE_PROJECT_ROOT ?? process.cwd());
+const resolvedPath = path.resolve(filePath);
+if (!resolvedPath.startsWith(projectRoot + path.sep) && resolvedPath !== projectRoot) {
+  process.exit(0);
+}
+
 try {
-  execFileSync("allium", ["check", filePath], {
+  execFileSync("allium", ["check", resolvedPath], {
     encoding: "utf-8",
     stdio: "pipe",
   });


### PR DESCRIPTION
## Summary

- The `allium-check.mjs` post-tool-use hook passes `file_path` from the Claude Code hook framework directly to the `allium` CLI binary without validating the path stays within the project directory
- While `execFileSync` prevents shell injection, paths pointing outside the project (e.g. `/etc/passwd`, `~/.ssh/id_rsa`) could leak filesystem information through allium's error output
- Fix adds `path.resolve()` + `startsWith(projectRoot + path.sep)` boundary check before invoking allium
- Files outside the project root are silently skipped (`process.exit(0)`) — no error, no information leakage
- The `path.sep` boundary prevents prefix confusion (e.g. `/home/user/project` matching `/home/user/projectother`)
- Project root is determined via `CLAUDE_PROJECT_ROOT` env var (set by hook framework) with `cwd()` fallback

## Test plan

- [x] Verify `.allium` files within the project directory are still checked by allium as before
- [x] Verify paths outside the project root (e.g. `/tmp/malicious.allium`) cause silent exit with code 0
- [x] Verify path traversal attempts (e.g. `../../etc/passwd.allium`) are resolved and rejected
- [x] Verify prefix boundary: `/home/user/projectother/file.allium` is rejected when project root is `/home/user/project`
- [x] Verify `CLAUDE_PROJECT_ROOT` env var is respected when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)