### PR TITLE
Portable agents: skills + VS Code subagents

### DIFF
--- a/.github/agents/tend.agent.md
+++ b/.github/agents/tend.agent.md
@@ -1,0 +1,75 @@
+---
+name: tend
+description: "Tend the Allium garden. Use when the user wants to write, edit, update, add to, improve, clarify, refine, restructure, fix or migrate Allium specs. Covers adding entities, rules, triggers, surfaces and contracts, fixing syntax or validation errors, renaming or refactoring within specs, migrating specs to a new language version, and translating requirements into well-formed specifications. Pushes back on vague requirements."
+---
+
+# Tend
+
+You tend the Allium garden. You are responsible for the health and integrity of `.allium` specification files. You are senior, opinionated and precise. When a request is vague, you push back and ask probing questions rather than guessing.
+
+## Startup
+
+1. Read [language reference](../../references/language-reference.md) for the Allium syntax and validation rules.
+2. Read the relevant `.allium` files (search the project to find them if not specified).
+3. If the `allium` CLI is available, run `allium check` against the files to verify they are syntactically correct before making any changes.
+4. Understand the existing domain model before proposing changes.
+
+## What you do
+
+You take requests for new or changed system behaviour and translate them into well-formed Allium specifications. This means:
+
+- Adding new entities, variants, rules or triggers to existing specs.
+- Modifying existing specifications to accommodate changed requirements.
+- Restructuring specs when they've grown unwieldy or when concerns need separating.
+- Cross-file renames and refactors within the spec layer.
+- Fixing validation errors or syntax issues in `.allium` files.
+
+## How you work
+
+**Challenge vagueness.** If a request doesn't specify what happens at boundaries, under failure, or in concurrent scenarios, say so. Ask what should happen rather than inventing behaviour. A spec that papers over ambiguity is worse than no spec. Record unresolved questions as `open question` declarations rather than assuming an answer.
+
+**Find the right abstraction.** Specs describe observable behaviour, not implementation. Two tests help:
+
+- *Why does the stakeholder care?* "Sessions stored in Redis": they don't. "Sessions expire after 24 hours": they do. Include the second, not the first.
+- *Could it be implemented differently and still be the same system?* If yes, you're looking at an implementation detail. Abstract it.
+
+If the caller describes a feature in implementation terms ("the API returns a 404", "we use a cron job"), translate to behavioural terms ("the user is informed it's not found", "this happens on a schedule").
+
+**Respect what's there.** Read the existing specs thoroughly before changing them. Understand the domain model, the entity relationships and the rule interactions. New behaviour should fit into the existing structure, not fight it.
+
+**Spot library spec candidates.** If the behaviour being described is a standard integration (OAuth, payment processing, email delivery, webhook handling), it may belong in a standalone library spec rather than inline. Ask whether this integration is specific to the system or generic enough to reuse.
+
+**Be minimal.** Add what's needed and nothing more. Don't speculatively add fields, rules or config that weren't asked for. Don't restructure working specs for aesthetic reasons.
+
+## Boundaries
+
+- You work on `.allium` files only. You do not modify implementation code.
+- You do not check alignment between specs and code. That belongs to the `weed` skill.
+- You do not extract specifications from existing code. That belongs to the `distill` skill.
+- You do not run structured discovery sessions. When requirements are unclear or the change involves new feature areas with complex entity relationships, that belongs to the `elicit` skill. You handle targeted changes where the caller already knows what they want.
+- You do not modify `references/language-reference.md`. The language definition is governed separately.
+
+## Spec writing guidelines
+
+- Preserve the existing `-- allium: N` version marker. Do not change the version number.
+- Follow the section ordering defined in the language reference.
+- Use `config` blocks for variable values. Do not hardcode numbers in rules.
+- Temporal triggers always need `requires` guards to prevent re-firing.
+- Use `with` for relationships, `where` for projections. Do not swap them.
+- `transitions_to` fires on field transition only (not creation). `becomes` fires on both creation and transition. Do not swap them.
+- Capitalised pipe values are variant references. Lowercase pipe values are enum literals.
+- New entities use `.created()` in `ensures` clauses. Variant instances use the variant name.
+- Inline enums compared across fields must be extracted to named enums.
+- Collection operations use explicit parameter syntax: `items.any(i => i.active)`.
+- Place new declarations in the correct section per the file structure.
+- `@guidance` in rules is optional and must be the final clause (after `ensures:`).
+- Use `contract` declarations for obligation blocks. All contracts are module-level declarations referenced from surfaces via `contracts: demands Name, fulfils Name`.
+- Expression-bearing invariants use `invariant Name { expression }` syntax (no `@`). Prose-only invariants use `@invariant Name` (with `@`, no colon). The `@` sigil marks annotations whose structure the checker validates but whose prose content it does not evaluate.
+- `@guarantee Name` in surfaces is the prose counterpart to expression-bearing invariants. Same `@` sigil convention.
+- `@guidance` must appear after all structural clauses and after all other annotations in its containing construct.
+- Config defaults can reference other modules' config via qualified names (`other/config.param`). Expression-form defaults support arithmetic (`base_timeout * 2`).
+- `implies` is available in all expression contexts. `a implies b` is `not a or b`, with the lowest boolean precedence.
+
+## Output
+
+When proposing spec changes, explain the behavioural intent first, then show the changes. If you have questions or concerns about the request, raise them before writing anything.

--- a/.github/agents/weed.agent.md
+++ b/.github/agents/weed.agent.md
@@ -1,0 +1,84 @@
+---
+name: weed
+description: "Weed the Allium garden. Find where Allium specifications and implementation code have diverged, and help resolve the divergences. Use when the user wants to check spec-code alignment, compare specs against implementation, audit for spec drift or violations, sync specs with code or code with specs, or verify whether the implementation matches what the spec says."
+---
+
+# Weed
+
+You weed the Allium garden. You compare `.allium` specifications against implementation code, find where they have diverged, and help resolve the divergences.
+
+## Startup
+
+1. Read [language reference](../../references/language-reference.md) for the Allium syntax and validation rules.
+2. Read the relevant `.allium` files (search the project to find them if not specified).
+3. If the `allium` CLI is available, run `allium check` against the files to verify they are syntactically correct.
+4. Read the corresponding implementation code.
+
+## Modes
+
+You operate in one of three modes, determined by the caller's request:
+
+**Check.** Read both spec and code. Report every divergence with its location in both. Do not modify anything.
+
+**Update spec.** Modify the `.allium` files to match what the code actually does. The spec becomes a faithful description of current behaviour.
+
+**Update code.** Modify the implementation to match what the spec says. The code becomes a faithful implementation of specified behaviour.
+
+If no mode is specified, default to **check** and present findings before making changes.
+
+## How you work
+
+For each entity, rule or trigger in the spec, find the corresponding implementation. For each significant code path, check whether the spec accounts for it. Report mismatches in both directions: spec says X but code does Y, and code does Z but the spec is silent.
+
+## Divergence classification
+
+When you find a mismatch, do not assume which side is correct. Report each divergence as one of:
+
+- **Spec bug.** The spec is wrong, code is correct. Fix the spec.
+- **Code bug.** The code is wrong, spec is correct. Fix the code.
+- **Aspirational design.** The spec describes intended future behaviour. Leave both as-is but note the gap.
+- **Intentional gap.** The divergence is deliberate (e.g. spec abstracts away an implementation detail). Leave both as-is.
+
+Present divergences grouped by entity or rule for easier review.
+
+When code has repeated interface contracts across service boundaries (e.g. the same serialisation requirement in multiple integration points), check whether the spec uses `contract` declarations for reuse. Code assertions and invariants (e.g. `assert balance >= 0`, class-level validators) should align with spec invariants. If the spec lacks a corresponding `invariant Name { expression }`, flag the gap.
+
+## Guidelines for spec updates
+
+- Preserve the existing `-- allium: N` version marker. Do not change the version number.
+- Follow the section ordering defined in the language reference.
+- Describe behaviour, not implementation. If you find yourself writing field names that imply storage mechanisms or API details, rephrase.
+- Use `config` blocks for variable values (thresholds, timeouts, limits). Do not hardcode numbers in rules.
+- Temporal triggers always need `requires` guards to prevent re-firing.
+- Use `with` for relationships, `where` for projections. Do not swap them.
+- Inline enums compared across fields must be extracted to named enums.
+- When adding new rules or entities, place them in the correct section per the file structure.
+- Config values derived from other services' config (e.g. `extended_timeout = base_timeout * 2`) should use qualified references or expression-form defaults in the spec.
+
+## Guidelines for code updates
+
+- Follow the project's existing conventions for style, structure and naming.
+- Run tests after making changes. If tests fail, report the failures rather than silently adjusting tests.
+- Flag changes that have implications beyond the immediate file (e.g. API contract changes, database migrations, downstream consumers).
+- Prefer minimal, targeted changes. Do not refactor surrounding code unless directly required by the divergence fix.
+- If a code change requires a migration or deployment step, note this explicitly.
+
+## Boundaries
+
+- You do not build new specifications from scratch. That belongs to the `tend` skill or the `elicit` skill.
+- You do not extract specifications from code. That belongs to the `distill` skill.
+- You do not modify `references/language-reference.md`. The language definition is governed separately.
+- You do not make architectural decisions. Flag wider implications and let the caller decide.
+
+## Output format
+
+When reporting divergences (check mode), use this structure for each finding:
+
+```
+### [Entity/Rule name]
+Spec: [what the spec says] (file:line)
+Code: [what the code does] (file:line)
+Classification: [ask user]
+```
+
+Group related divergences together. Lead with the most consequential findings.

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -1,0 +1,20 @@
+name: Check generated files
+
+on:
+  pull_request:
+    paths:
+      - '.claude/agents/**'
+      - 'skills/tend/**'
+      - 'skills/weed/**'
+      - '.github/agents/**'
+      - 'scripts/generate-multi-editor.mjs'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: node scripts/generate-multi-editor.mjs --check

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -1,20 +1,22 @@
-name: Check generated files
+name: Validate skills and agents
 
 on:
   pull_request:
     paths:
+      - 'SKILL.md'
       - '.claude/agents/**'
-      - 'skills/tend/**'
-      - 'skills/weed/**'
+      - 'skills/**'
       - '.github/agents/**'
+      - 'references/**'
       - 'scripts/generate-multi-editor.mjs'
+      - 'scripts/test-skills.mjs'
 
 jobs:
-  check:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-      - run: node scripts/generate-multi-editor.mjs --check
+      - run: node scripts/test-skills.mjs

--- a/README.md
+++ b/README.md
@@ -8,58 +8,56 @@ Give your AI agents something more useful than a prompt. [juxt.github.io/allium]
 
 ## Get started
 
-**Claude Code** (via the JUXT plugin marketplace):
+Allium works with Claude Code, Copilot, Cursor, Windsurf, Aider, Continue and 40+ other tools. How you install depends on your editor, but everything converges on the same skills and agents.
+
+**Claude Code:**
 
 ```
 /plugin marketplace add juxt/claude-plugins
 /plugin install allium
 ```
 
-**Cursor, Windsurf, Copilot, Aider, Continue and 40+ other tools:**
+**Cursor, Windsurf, Aider, Continue and other skills-compatible tools:**
 
 ```
 npx skills add juxt/allium
 ```
 
-Once installed, type `/allium` to get started. Allium examines your project and offers to distill from existing code or build a new spec through conversation. You can also jump straight to a specific mode:
+**GitHub Copilot:** agent files in `.github/agents/` are picked up automatically. No installation needed.
 
-- `/allium:elicit` — build a spec through structured conversation with stakeholders
-- `/allium:distill` — extract a spec from existing code
-- `/allium:propagate` — generate tests from a specification
+Once installed:
 
-Tend and propagate are Allium's built-in agent and skill. Tend updates your specs, propagate generates tests from them. Both work with whatever LLM tooling you have installed.
+- **Claude Code, Cursor, Windsurf, etc.** — type `/allium` to get started. Allium examines your project and offers to distill from existing code or build a new spec through conversation. You can also jump to `/allium:elicit`, `/allium:distill` or `/allium:propagate` directly.
+- **GitHub Copilot** — use `@tend` or `@weed` with a request. Copilot surfaces the agents directly; the slash-command skills are not available.
 
 Jump to what [Allium looks like in practice](#what-this-looks-like-in-practice).
 
-## Working with agents
+## Skills and agents
 
-A [rule](.claude/rules/allium.md) loads automatically whenever Claude Code works with `.allium` files. It provides syntax guidance, naming conventions and common pitfalls without needing to invoke the skill. This keeps routine spec reads and edits fast.
+Allium ships as both **skills** (interactive, invoked with `/allium`) and **agents** (autonomous, delegated to a subcontext). Different editors surface these differently.
 
-Two specialised agents handle `.allium` files in a delegated context. They load the language reference into their own conversation, keeping Allium syntax out of your main session and freeing you to work on implementation in parallel.
+| Capability | Claude Code | Copilot | Cursor, Windsurf, etc. |
+|---|---|---|---|
+| Skills (`/allium`, `/allium:elicit`, etc.) | `/allium` slash commands | — | `/allium` slash commands |
+| Tend agent | Automatic (natural language) | `@tend` agent | `/allium:tend` skill |
+| Weed agent | Automatic (natural language) | `@weed` agent | `/allium:weed` skill |
+| Auto-trigger on `.allium` files | Rule loads automatically | — | Skill auto-triggers |
 
-**[tend](.claude/agents/tend.md)** grows and shapes specifications. It translates new requirements into well-formed specs, challenges vague requests and won't let ambiguity through. It works on `.allium` files only.
+Across all editors, tend and weed load the language reference into their own context, keeping Allium syntax out of your main session.
 
-```
-"Tend: we need a cancellation policy for subscriptions
- with a cooling-off period and prorated refunds"
+**Tend** grows and shapes specifications. It translates new requirements into well-formed specs, challenges vague requests and won't let ambiguity through. It works on `.allium` files only.
 
-"Tend: add a circuit breaker entity to the infrastructure spec"
+| Claude Code | Copilot | Cursor, Windsurf, etc. |
+|---|---|---|
+| "add a cancellation policy to the subscription spec" | `@tend add a cancellation policy to the subscription spec` | `/allium:tend add a cancellation policy to the subscription spec` |
+| "restructure the auth spec, the rules have grown unwieldy" | `@tend restructure the auth spec` | `/allium:tend restructure the auth spec` |
 
-"Tend: restructure the authentication spec, the rules have grown unwieldy"
-```
+**Weed** finds where specifications and implementation have diverged. It reports mismatches and can update either side to match.
 
-**[weed](.claude/agents/weed.md)** finds where specifications and implementation have diverged. It reports mismatches and can update either side to match.
-
-```
-"Weed the auth spec against src/auth/"
-
-"Weed: update the spec to match what the payment code actually does"
-
-"Weed: the order spec says cancelled orders can't be refunded
- but the code allows it. Fix the code."
-```
-
-Use `/allium` for interactive spec work, `elicit` to build specs through conversation, `distill` to extract specs from code, `tend` to grow specs as requirements evolve, `weed` to catch drift between spec and code.
+| Claude Code | Copilot | Cursor, Windsurf, etc. |
+|---|---|---|
+| "check the auth spec against src/auth/" | `@weed check the auth spec against src/auth/` | `/allium:weed check the auth spec against src/auth/` |
+| "the order spec says cancelled orders can't be refunded but the code allows it. Fix the code." | `@weed fix the order cancellation code to match the spec` | `/allium:weed fix the order cancellation code to match the spec` |
 
 ## The problem with conversational context
 
@@ -72,7 +70,7 @@ Allium gives behavioural intent a durable form that doesn't drift with the conve
 
 Modern LLMs navigate codebases effectively, and many engineers find this sufficient. The limitation appears when you need to distinguish what the code *does* from what it *should do*. Code captures implementation, including bugs and expedient decisions. The model treats all of it as intended behaviour.
 
-Precise prompting helps, but precise prompting means specifying intent: which behaviours are deliberate, which constraints must be preserved. You end up writing descriptions of intent distributed across your prompts. Allium captures this in a form that persists. The next engineer, or the next model, or you next week, can understand not just what the system does but what it was meant to do.
+Precise prompting helps, but precise prompting means specifying intent: which behaviours are deliberate, which constraints must be preserved. You end up writing descriptions of intent distributed across your prompts. Allium captures this in a form that persists. The next engineer, or the next model, or you next week, can understand what the system does and what it was meant to do.
 
 ## Why not capture requirements in markdown?
 
@@ -82,11 +80,11 @@ Allium's structure makes contradictions visible. When two rules have incompatibl
 
 ## Iterating on specifications
 
-The specification and the code evolve together. Writing and refining a behavioural model alongside implementation sharpens your understanding of both the problem and your solution. Questions surface that you wouldn't have thought to ask; constraints emerge that only become visible when you try to formalise them.
+The specification and the code evolve together. Writing and refining a behavioural model alongside implementation deepens your understanding of both the problem and your solution. Questions surface that you wouldn't have thought to ask; constraints emerge that only become visible when you try to formalise them.
 
 Manual coding embedded this discovery in the act of implementation. LLMs generate code from descriptions, shifting where design thinking occurs. Allium captures it explicitly: the specification becomes the site of that thinking, the code its expression.
 
-Two processes feed this growth: **elicitation** works forward from intent through structured conversations with stakeholders, while **distillation** works backward from implementation to capture what the system actually does, including behaviours that were never explicitly decided. Distillation reveals what you built; elicitation clarifies what you meant. When these diverge, you've found something worth investigating.
+Two processes feed this growth: **elicitation** works forward from intent through structured conversations with stakeholders, while **distillation** works backward from implementation to capture what the system actually does, including behaviours that were never explicitly decided. When distillation and elicitation diverge, you've found something worth investigating.
 
 See the [elicitation guide](skills/elicit/SKILL.md) and the [distillation guide](skills/distill/SKILL.md) for detailed approaches.
 
@@ -94,7 +92,7 @@ See the [elicitation guide](skills/elicit/SKILL.md) and the [distillation guide]
 
 A common objection is that maintaining behavioural models alongside code violates the single source of truth principle. But code captures both intentional and accidental behaviour, with no mechanism to distinguish them. Is that authentication quirk a feature or a bug? The code can't tell you. You need something outside the code to even articulate "this behaviour is wrong". Engineers already accept this in other contexts: type systems express intent that code must satisfy, tests assert expected behaviour against actual behaviour. These aren't duplication.
 
-Allium applies the same pattern. Code excels at expressing *how*; behavioural models excel at expressing *what* and *under which conditions*. When these disagree, that disagreement is information. Perhaps the implementation drifted from intent, or perhaps the model was naive. Either might need to change. The gap between them surfaces questions you need to answer. Redundancy, in this context, isn't overhead. It's resilience.
+Allium applies the same pattern. Code excels at expressing *how*; behavioural models excel at expressing *what* and *under which conditions*. When these disagree, that disagreement is information. Perhaps the implementation drifted from intent, or perhaps the model was naive. Either might need to change. The gap between them surfaces questions you need to answer, and that redundancy is what makes the system resilient.
 
 ## What Allium captures
 
@@ -196,7 +194,7 @@ The [language reference](references/language-reference.md) covers entities, rule
 
 Allium has no compiler and no runtime. It is purely descriptive, defined entirely by its documentation.
 
-In an era where LLMs function as pseudocode compilers, executing informal descriptions into working code, a well-structured behavioural language becomes the mechanism for ensuring that what gets compiled is what you actually meant. The behavioural model is the primary artefact; the code that implements it is secondary.
+LLMs already function as pseudocode compilers, executing informal descriptions into working code. A well-structured behavioural language ensures that what gets compiled is what you actually meant. The behavioural model is the primary artefact; the code that implements it is secondary.
 
 ## What this looks like in practice
 
@@ -278,7 +276,7 @@ Code and intent diverge silently over time. Allium gives the LLM something to ch
 
 ## Verification
 
-When the [Allium CLI](https://github.com/juxt/allium-tools) is installed, `.allium` files are validated automatically after every write or edit in Claude Code. Install it via Homebrew (`brew tap juxt/allium && brew install allium`) or Cargo (`cargo install allium-cli`). Diagnostics appear inline and the model fixes issues in the same turn.
+When the [Allium CLI](https://github.com/juxt/allium-tools) is installed, `.allium` files are validated automatically after every write or edit. Install it via Homebrew (`brew tap juxt/allium && brew install allium`) or Cargo (`cargo install allium-cli`). Diagnostics appear inline and the model fixes issues in the same turn.
 
 Without the CLI, the skill falls back to validating against the language reference. The CLI catches more, particularly parser-level errors and cross-entity reference checks, so installing it is recommended if you're working with Allium regularly.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -30,8 +30,8 @@ Allium does NOT specify programming language or framework choices, database sche
 | Writing or reading `.allium` files | this skill | You need language syntax and structure |
 | Building a spec through conversation | `elicit` skill | User describes a feature or behaviour they want to build |
 | Extracting a spec from existing code | `distill` skill | User has implementation code and wants a spec from it |
-| Modifying an existing spec | `tend` agent | User wants targeted changes to `.allium` files |
-| Checking spec-to-code alignment | `weed` agent | User wants to find or fix divergences between spec and implementation |
+| Modifying an existing spec | `tend` skill | User wants targeted changes to `.allium` files |
+| Checking spec-to-code alignment | `weed` skill | User wants to find or fix divergences between spec and implementation |
 | Generating tests from a spec | `propagate` skill | User wants to generate tests, PBT properties or state machine tests from a specification |
 
 ## Quick syntax summary

--- a/scripts/generate-multi-editor.mjs
+++ b/scripts/generate-multi-editor.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+/**
+ * Generates skill and VS Code agent variants from the canonical
+ * Claude Code agent definitions in .claude/agents/.
+ *
+ * Usage: node scripts/generate-multi-editor.mjs [--check]
+ *
+ * --check  Report whether generated files are up to date without writing.
+ *          Exits 1 if any file would change.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import path from "path";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const CHECK = process.argv.includes("--check");
+
+const AGENTS = ["tend", "weed"];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function read(rel) {
+  return readFileSync(path.join(ROOT, rel), "utf-8");
+}
+
+function write(rel, content) {
+  const abs = path.join(ROOT, rel);
+  mkdirSync(path.dirname(abs), { recursive: true });
+  if (existsSync(abs) && readFileSync(abs, "utf-8") === content) return false;
+  if (!CHECK) writeFileSync(abs, content);
+  return true;
+}
+
+function parseFrontmatter(src) {
+  const match = src.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) throw new Error("No frontmatter found");
+  const fm = {};
+  for (const line of match[1].split("\n")) {
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    let val = line.slice(idx + 1).trim();
+    if (val.startsWith('"') && val.endsWith('"')) val = val.slice(1, -1);
+    fm[key] = val;
+  }
+  return { frontmatter: fm, body: match[2] };
+}
+
+function adaptBody(body) {
+  return (
+    body
+      // Replace ${CLAUDE_PLUGIN_ROOT} paths with relative markdown links
+      .replace(
+        /`\$\{CLAUDE_PLUGIN_ROOT\}\/references\/language-reference\.md`/g,
+        "[language reference](../../references/language-reference.md)"
+      )
+      // Replace Claude Code tool names with generic instructions
+      .replace(/\(use `Glob` to find them if not specified\)/g, "(search the project to find them if not specified)")
+      // Replace "agent" cross-references with "skill" for portable contexts
+      .replace(/the `weed` agent/g, "the `weed` skill")
+      .replace(/the `tend` agent/g, "the `tend` skill")
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Skill generation
+// ---------------------------------------------------------------------------
+
+const SKILL_EXTRA_TEND = `
+## Context management
+
+Spec evolution can require many edit-validate cycles. If you anticipate a long iterative session, or if the context is growing large, advise the user to open a fresh chat specifically for tending the spec. Provide a copy-paste prompt so they can resume, such as: "Use the \`tend\` skill to continue updating the [Spec Name] spec to handle [Remaining Requirements]."
+
+## Verification
+
+After every edit to a \`.allium\` file, run \`allium check\` against the modified file if the CLI is installed. Fix any reported issues before presenting the result. If the CLI is not available, verify against the [language reference](../../references/language-reference.md).
+`;
+
+const SKILL_EXTRA_WEED = `
+## Context management
+
+Spec alignment checks can require many edit-validate cycles. If you anticipate a long iterative session, or if the context is growing large, advise the user to open a fresh chat specifically for weeding the spec. Provide a copy-paste prompt so they can resume, such as: "Use the \`weed\` skill to continue resolving divergences between the [Spec Name] spec and [Implementation Files]."
+
+## Verification
+
+After every edit to a \`.allium\` file, run \`allium check\` against the modified file if the CLI is installed. Fix any reported issues before presenting the result. If the CLI is not available, verify against the [language reference](../../references/language-reference.md).
+`;
+
+const SKILL_EXTRAS = { tend: SKILL_EXTRA_TEND, weed: SKILL_EXTRA_WEED };
+
+function generateSkill(name) {
+  const src = read(`.claude/agents/${name}.md`);
+  const { frontmatter, body } = parseFrontmatter(src);
+  const adapted = adaptBody(body);
+
+  // Insert extra sections before the final ## Output or ## Output format section
+  const extra = SKILL_EXTRAS[name];
+  let finalBody = adapted;
+  const outputMatch = adapted.match(/\n(## Output\b[^\n]*)/);
+  if (outputMatch) {
+    const idx = adapted.indexOf(outputMatch[0]);
+    finalBody = adapted.slice(0, idx) + extra + adapted.slice(idx);
+  } else {
+    finalBody = adapted + extra;
+  }
+
+  const skill = `---
+name: ${name}
+description: "${frontmatter.description}"
+---
+${finalBody}`;
+
+  return skill;
+}
+
+// ---------------------------------------------------------------------------
+// VS Code agent generation
+// ---------------------------------------------------------------------------
+
+function generateVscodeAgent(name) {
+  const src = read(`.claude/agents/${name}.md`);
+  const { frontmatter, body } = parseFrontmatter(src);
+  const adapted = adaptBody(body);
+
+  // Omit tools — VS Code defaults to all available tools.
+  // Claude Code's Bash restriction (allium check *) can't be expressed
+  // in VS Code's format, so we accept broader tool access.
+  const agent = `---
+name: ${name}
+description: "${frontmatter.description}"
+---
+${adapted}`;
+
+  return agent;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+let dirty = false;
+
+for (const name of AGENTS) {
+  if (write(`skills/${name}/SKILL.md`, generateSkill(name))) {
+    console.log(`${CHECK ? "out of date" : "wrote"}: skills/${name}/SKILL.md`);
+    dirty = true;
+  }
+  if (write(`.github/agents/${name}.agent.md`, generateVscodeAgent(name))) {
+    console.log(
+      `${CHECK ? "out of date" : "wrote"}: .github/agents/${name}.agent.md`
+    );
+    dirty = true;
+  }
+}
+
+if (CHECK && dirty) {
+  console.error(
+    "\nGenerated files are out of date. Run: node scripts/generate-multi-editor.mjs"
+  );
+  process.exit(1);
+}
+
+if (!dirty) {
+  console.log("All generated files are up to date.");
+}

--- a/scripts/test-skills.mjs
+++ b/scripts/test-skills.mjs
@@ -1,0 +1,479 @@
+#!/usr/bin/env node
+
+/**
+ * Validates that all skill and agent artifacts are structurally correct,
+ * correctly generated, properly isolated, and load in Claude Code.
+ *
+ * Usage:
+ *   node scripts/test-skills.mjs                  # all offline tests
+ *   node scripts/test-skills.mjs --live            # include Claude Code smoke tests
+ *   node scripts/test-skills.mjs structure         # run one group
+ *   node scripts/test-skills.mjs portability links # run multiple groups
+ *
+ * Groups: structure, portability, links, routing, generation, discovery, crosstalk
+ *
+ * The first five groups are offline (free, fast). The last two require --live
+ * and make Claude API calls.
+ */
+
+import { readFileSync, existsSync } from "fs";
+import { execFileSync, execSync } from "child_process";
+import path from "path";
+
+let _claudePath;
+function getClaudePath() {
+  if (!_claudePath) _claudePath = execSync("which claude", { encoding: "utf-8" }).trim();
+  return _claudePath;
+}
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const LIVE = process.argv.includes("--live");
+
+// Parse group filters from positional args (ignore flags)
+const requestedGroups = process.argv
+  .slice(2)
+  .filter((a) => !a.startsWith("--"));
+
+let passed = 0;
+let failed = 0;
+let skipped = 0;
+
+function pass(name) {
+  console.log(`  pass: ${name}`);
+  passed++;
+}
+
+function fail(name, detail) {
+  console.log(`  FAIL: ${name}${detail ? ` — ${detail}` : ""}`);
+  failed++;
+}
+
+function skip(name, reason) {
+  console.log(`  skip: ${name} — ${reason}`);
+  skipped++;
+}
+
+function rel(absPath) {
+  return path.relative(ROOT, absPath);
+}
+
+function shouldRun(group) {
+  return requestedGroups.length === 0 || requestedGroups.includes(group);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseFrontmatter(src) {
+  const match = src.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return null;
+  const fm = {};
+  const lines = match[1].split("\n");
+  let currentKey = null;
+  for (const line of lines) {
+    if (/^\s+-\s/.test(line) && currentKey) {
+      if (!Array.isArray(fm[currentKey])) fm[currentKey] = [];
+      fm[currentKey].push(line.replace(/^\s+-\s*/, "").trim());
+      continue;
+    }
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    let val = line.slice(idx + 1).trim();
+    if (val.startsWith('"') && val.endsWith('"')) val = val.slice(1, -1);
+    currentKey = key;
+    fm[key] = val || true;
+  }
+  return { frontmatter: fm, body: match[2] };
+}
+
+function resolveRelativeLinks(body, fileDir) {
+  const linkPattern = /\[.*?\]\((\.\.?\/[^)]+)\)/g;
+  const links = [];
+  let m;
+  while ((m = linkPattern.exec(body)) !== null) {
+    links.push(m[1]);
+  }
+  return links.map((link) => ({
+    link,
+    target: path.resolve(fileDir, link.replace(/#.*$/, "")),
+    exists: existsSync(path.resolve(fileDir, link.replace(/#.*$/, ""))),
+  }));
+}
+
+function claudeQuery(prompt, { cwd } = {}) {
+  const output = execFileSync(
+    getClaudePath(),
+    [
+      "--plugin-dir", ROOT,
+      "--print",
+      "--model", "haiku",
+      "--max-budget-usd", "0.05",
+      prompt,
+    ],
+    {
+      encoding: "utf-8",
+      timeout: 60000,
+      stdio: ["pipe", "pipe", "pipe"],
+      ...(cwd ? { cwd } : {}),
+    }
+  );
+  // Strip markdown code fences and try to extract JSON
+  const cleaned = output.replace(/```json\n?/g, "").replace(/```\n?/g, "").trim();
+  // Try object first (greedy), then array
+  for (const re of [/\{[\s\S]*\}/, /\[[\s\S]*\]/]) {
+    const match = cleaned.match(re);
+    if (match) {
+      try { return JSON.parse(match[0]); } catch { /* try next */ }
+    }
+  }
+  throw new Error(`No valid JSON in response: ${output.slice(0, 200)}`);
+}
+
+// Known paths
+const rootSkill = path.join(ROOT, "SKILL.md");
+const skillNames = ["distill", "elicit", "propagate", "tend", "weed"];
+const skillPaths = [rootSkill, ...skillNames.map((n) => path.join(ROOT, "skills", n, "SKILL.md"))];
+const agentPaths = ["tend", "weed"].map((n) => path.join(ROOT, ".claude", "agents", `${n}.md`));
+const vscodeAgentPaths = ["tend", "weed"].map((n) => path.join(ROOT, ".github", "agents", `${n}.agent.md`));
+const portableSkillNames = ["tend", "weed"];
+
+// Patterns that should not appear in portable artifacts
+const CLAUDE_CODE_LEAKS = [
+  [/\buse `Glob`\b/, "Glob"],
+  [/\buse `Grep`\b/, "Grep"],
+  [/\bBash\(allium check\b/, "Bash(allium check)"],
+  [/\$\{CLAUDE_PLUGIN_ROOT\}/, "${CLAUDE_PLUGIN_ROOT}"],
+  [/the `\w+` agent\b/, "agent cross-reference (should be 'skill')"],
+];
+
+function checkLeaks(body) {
+  return CLAUDE_CODE_LEAKS.filter(([re]) => re.test(body)).map(([, name]) => name);
+}
+
+// ---------------------------------------------------------------------------
+// Structure — frontmatter validity for all artifact types
+// ---------------------------------------------------------------------------
+
+if (shouldRun("structure")) {
+  console.log("\n── structure: frontmatter validation ──\n");
+
+  for (const skillPath of skillPaths) {
+    const label = rel(skillPath);
+    if (!existsSync(skillPath)) { fail(label, "file not found"); continue; }
+    const parsed = parseFrontmatter(readFileSync(skillPath, "utf-8"));
+    if (!parsed) { fail(label, "no valid frontmatter"); continue; }
+    const { frontmatter } = parsed;
+    if (!frontmatter.name) fail(`${label}`, "missing 'name'");
+    else if (!frontmatter.description) fail(`${label}`, "missing 'description'");
+    else pass(`${label}`);
+  }
+
+  console.log("");
+
+  for (const agentPath of agentPaths) {
+    const label = rel(agentPath);
+    if (!existsSync(agentPath)) { fail(label, "file not found"); continue; }
+    const parsed = parseFrontmatter(readFileSync(agentPath, "utf-8"));
+    if (!parsed) { fail(label, "no valid frontmatter"); continue; }
+    const missing = ["name", "description", "model", "tools"].filter((k) => !parsed.frontmatter[k]);
+    if (missing.length > 0) fail(`${label}`, `missing: ${missing.join(", ")}`);
+    else pass(`${label}`);
+  }
+
+  console.log("");
+
+  for (const agentPath of vscodeAgentPaths) {
+    const label = rel(agentPath);
+    if (!existsSync(agentPath)) { fail(label, "file not found"); continue; }
+    const parsed = parseFrontmatter(readFileSync(agentPath, "utf-8"));
+    if (!parsed) { fail(label, "no valid frontmatter"); continue; }
+    const { frontmatter } = parsed;
+    if (!frontmatter.name || !frontmatter.description) {
+      fail(`${label}`, "missing name or description");
+    } else {
+      pass(`${label}`);
+    }
+    // VS Code doesn't support model or tools
+    const unsupported = ["model", "tools"].filter((k) => frontmatter[k]);
+    if (unsupported.length > 0) {
+      fail(`${label} vs-code compat`, `unsupported fields: ${unsupported.join(", ")}`);
+    } else {
+      pass(`${label} vs-code compat`);
+    }
+    // Naming convention
+    if (!path.basename(agentPath).endsWith(".agent.md")) {
+      fail(`${label} naming`, "must end with .agent.md");
+    } else {
+      pass(`${label} naming`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Portability — no Claude Code references in portable artifacts
+// ---------------------------------------------------------------------------
+
+if (shouldRun("portability")) {
+  console.log("\n── portability: no Claude Code leakage ──\n");
+
+  // All skills must not contain unexpanded placeholders
+  for (const skillPath of skillPaths) {
+    if (!existsSync(skillPath)) continue;
+    const parsed = parseFrontmatter(readFileSync(skillPath, "utf-8"));
+    if (!parsed) continue;
+    const label = rel(skillPath);
+    if (parsed.body.includes("${CLAUDE_PLUGIN_ROOT}")) {
+      fail(`${label}`, "contains unexpanded ${CLAUDE_PLUGIN_ROOT}");
+    } else {
+      pass(`${label} no placeholders`);
+    }
+  }
+
+  console.log("");
+
+  // Portable skills and VS Code agents must not reference Claude Code tools
+  const portableArtifacts = [
+    ...portableSkillNames.map((n) => path.join(ROOT, "skills", n, "SKILL.md")),
+    ...vscodeAgentPaths,
+  ];
+  for (const filePath of portableArtifacts) {
+    if (!existsSync(filePath)) continue;
+    const parsed = parseFrontmatter(readFileSync(filePath, "utf-8"));
+    if (!parsed) continue;
+    const leaks = checkLeaks(parsed.body);
+    const label = rel(filePath);
+    if (leaks.length > 0) {
+      fail(`${label}`, `Claude Code references: ${leaks.join(", ")}`);
+    } else {
+      pass(`${label}`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Links — all relative markdown links resolve to real files
+// ---------------------------------------------------------------------------
+
+if (shouldRun("links")) {
+  console.log("\n── links: relative link resolution ──\n");
+
+  const allPaths = [...skillPaths, ...agentPaths, ...vscodeAgentPaths];
+  for (const filePath of allPaths) {
+    if (!existsSync(filePath)) continue;
+    const parsed = parseFrontmatter(readFileSync(filePath, "utf-8"));
+    if (!parsed) continue;
+    const links = resolveRelativeLinks(parsed.body, path.dirname(filePath));
+    const broken = links.filter((l) => !l.exists);
+    for (const { link } of broken) {
+      fail(`${rel(filePath)}`, `broken link: ${link}`);
+    }
+    if (broken.length === 0) {
+      pass(`${rel(filePath)} (${links.length} link${links.length !== 1 ? "s" : ""})`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Routing — root SKILL.md routing table matches actual skill directories
+// ---------------------------------------------------------------------------
+
+if (shouldRun("routing")) {
+  console.log("\n── routing: skill routing table ──\n");
+
+  const rootSrc = readFileSync(rootSkill, "utf-8");
+  const routingRefs = [...rootSrc.matchAll(/`(\w+)` skill/g)].map((m) => m[1]);
+  for (const name of routingRefs) {
+    if (name === "this") continue;
+    const target = path.join(ROOT, "skills", name, "SKILL.md");
+    if (existsSync(target)) {
+      pass(`${name}`);
+    } else {
+      fail(`${name}`, "skill directory not found");
+    }
+  }
+
+  // Reverse check: every skill directory should be referenced in the routing table
+  for (const name of skillNames) {
+    if (routingRefs.includes(name)) {
+      pass(`${name} in routing table`);
+    } else {
+      fail(`${name}`, "skill exists but not in routing table");
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Generation — generated files match what the script would produce
+// ---------------------------------------------------------------------------
+
+if (shouldRun("generation")) {
+  console.log("\n── generation: roundtrip check ──\n");
+
+  try {
+    execFileSync(
+      "node",
+      [path.join(ROOT, "scripts", "generate-multi-editor.mjs"), "--check"],
+      { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
+    );
+    pass("generated files up to date");
+  } catch {
+    fail("generated files out of date", "run: node scripts/generate-multi-editor.mjs");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Discovery — live Claude Code skill and agent loading
+// ---------------------------------------------------------------------------
+
+if (shouldRun("discovery")) {
+  console.log("\n── discovery: Claude Code skill/agent loading ──\n");
+
+  if (!LIVE) {
+    skip("skill discovery", "pass --live to enable (uses API tokens)");
+    skip("agent discovery", "pass --live to enable");
+  } else {
+    try {
+      const skills = claudeQuery(
+        "List every allium skill available to you. Output ONLY a JSON array of " +
+        'skill names without the allium: prefix, e.g. ["foo","bar"]. No other text.'
+      );
+      const missing = skillNames.filter((s) => !skills.includes(s));
+      const extra = skills.filter((s) => !skillNames.includes(s));
+      if (missing.length > 0) fail("skill discovery", `missing: ${missing.join(", ")}`);
+      else if (extra.length > 0) fail("skill discovery", `unexpected: ${extra.join(", ")}`);
+      else pass(`skill discovery (${skills.length} skills)`);
+    } catch (e) {
+      fail("skill discovery", e.message?.slice(0, 200));
+    }
+
+    try {
+      const agents = claudeQuery(
+        "List every allium agent (subagent_type) available to you via the Agent tool. " +
+        'Output ONLY a JSON array of agent names, e.g. ["foo","bar"]. No other text.'
+      );
+      const expectedAgents = ["tend", "weed"];
+      const missing = expectedAgents.filter((a) => !agents.includes(a));
+      if (missing.length > 0) fail("agent discovery", `missing: ${missing.join(", ")}`);
+      else pass(`agent discovery (${agents.length} agents)`);
+    } catch (e) {
+      fail("agent discovery", e.message?.slice(0, 200));
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Crosstalk — skills from the plugin don't bleed into unrelated projects,
+//             and local .claude/agents/ don't leak outside the repo
+// ---------------------------------------------------------------------------
+
+if (shouldRun("crosstalk")) {
+  console.log("\n── crosstalk: isolation between contexts ──\n");
+
+  if (!LIVE) {
+    skip("crosstalk", "pass --live to enable (uses API tokens)");
+  } else {
+    // From a neutral directory (/tmp), only plugin-provided skills should
+    // appear. Local .claude/agents/ from the allium repo must not leak.
+    // Note: plugin agents only load in the project where the plugin is
+    // installed, so from /tmp we expect skills but not agents.
+    try {
+      const result = claudeQuery(
+        "List EVERY skill available to you that contains 'tend' or 'weed' in the name. " +
+        'Output ONLY a JSON array of their exact names, e.g. ["allium:tend"]. No other text.',
+        { cwd: "/tmp" }
+      );
+
+      // Unprefixed names would mean local .claude/agents/ leaked
+      const unprefixed = result.filter((s) => s === "tend" || s === "weed");
+      if (unprefixed.length > 0) {
+        fail("neutral dir", `local artifacts leaked: ${unprefixed.join(", ")}`);
+      } else {
+        pass("neutral dir: no local artifact bleed");
+      }
+
+      // Prefixed plugin skills should be present
+      const prefixed = result.filter(
+        (s) => s === "allium:tend" || s === "allium:weed"
+      );
+      if (prefixed.length >= 2) {
+        pass("neutral dir: plugin skills present");
+      } else {
+        fail("neutral dir: plugin skills", `expected allium:tend and allium:weed, got: ${result.join(", ")}`);
+      }
+    } catch (e) {
+      fail("neutral dir", e.message?.slice(0, 200));
+    }
+
+    // From inside the allium repo, both plugin skills (allium:tend) and
+    // local agents (tend) should be present. This is expected and correct:
+    // contributors working on the repo need the local agents.
+    try {
+      const result = claudeQuery(
+        "List EVERY skill AND agent (subagent_type) available to you that contains " +
+        "'tend' or 'weed'. Output ONLY a JSON object: " +
+        '{"skills": [...], "agents": [...]}. Exact names. No other text.',
+        { cwd: ROOT }
+      );
+
+      const { skills = [], agents = [] } = result;
+
+      // Plugin skills should be present
+      const pluginSkills = skills.filter(
+        (s) => s === "allium:tend" || s === "allium:weed"
+      );
+      if (pluginSkills.length >= 2) {
+        pass("allium repo: plugin skills present");
+      } else {
+        fail("allium repo: plugin skills", `expected allium:tend and allium:weed, got: ${skills.join(", ")}`);
+      }
+
+      // Local agents should also be present (from .claude/agents/)
+      const localAgents = agents.filter((a) => a === "tend" || a === "weed");
+      if (localAgents.length >= 2) {
+        pass("allium repo: local agents present");
+      } else {
+        // Not a failure, just informational — depends on plugin install state
+        skip("allium repo: local agents", `got: ${agents.join(", ") || "(none)"}`);
+      }
+
+      // There should NOT be unprefixed tend/weed as skills (that would
+      // mean skills and agents are colliding)
+      const unprefixedSkills = skills.filter(
+        (s) => s === "tend" || s === "weed"
+      );
+      if (unprefixedSkills.length > 0) {
+        fail("allium repo: skill/agent collision", `unprefixed skills: ${unprefixedSkills.join(", ")}`);
+      } else {
+        pass("allium repo: no skill/agent collision");
+      }
+    } catch (e) {
+      fail("allium repo", e.message?.slice(0, 200));
+    }
+
+    // Advisory: warn about global plugin installation
+    try {
+      const listOutput = execSync("claude plugin list", { encoding: "utf-8" });
+      if (/allium.*enabled/i.test(listOutput)) {
+        console.log(
+          "\n  note: allium plugin is installed. Crosstalk tests account for this.\n" +
+          "  For full isolation, disable it temporarily:\n" +
+          "    claude plugin disable allium\n" +
+          "    node scripts/test-skills.mjs --live crosstalk\n" +
+          "    claude plugin enable allium"
+        );
+      }
+    } catch {
+      // Not critical
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`\n${"─".repeat(40)}`);
+console.log(`${passed} passed, ${failed} failed, ${skipped} skipped`);
+process.exit(failed > 0 ? 1 : 0);

--- a/skills/distill/SKILL.md
+++ b/skills/distill/SKILL.md
@@ -863,7 +863,7 @@ If any remain, ask: "Would a stakeholder include this in a requirements doc?"
 
 ## After distillation
 
-The extracted spec is a starting point. For targeted changes as requirements evolve, use the `tend` agent. For checking ongoing alignment between the spec and implementation, use the `weed` agent.
+The extracted spec is a starting point. For targeted changes as requirements evolve, use the `tend` skill. For checking ongoing alignment between the spec and implementation, use the `weed` skill.
 
 ## References
 

--- a/skills/elicit/SKILL.md
+++ b/skills/elicit/SKILL.md
@@ -335,7 +335,7 @@ A comment noting that two terms are equivalent is not a resolution. It guarantee
 
 ## After elicitation
 
-For targeted changes where you already know what you want, use the `tend` agent. For substantial additions that need structured discovery (new feature areas, complex entity relationships, unclear requirements), elicit is still the right tool even if a spec already exists. Checking alignment between specs and implementation belongs to the `weed` agent.
+For targeted changes where you already know what you want, use the `tend` skill. For substantial additions that need structured discovery (new feature areas, complex entity relationships, unclear requirements), elicit is still the right tool even if a spec already exists. Checking alignment between specs and implementation belongs to the `weed` skill.
 
 ## References
 

--- a/skills/propagate/SKILL.md
+++ b/skills/propagate/SKILL.md
@@ -107,7 +107,7 @@ Once the map is built, the PBT framework can walk random valid paths: start at a
 
 ## The implementation bridge
 
-You correlate spec constructs with implementation code, the same way the weed agent correlates for divergence checking.
+You correlate spec constructs with implementation code, the same way the weed skill correlates for divergence checking.
 
 ### For surface tests
 

--- a/skills/tend/SKILL.md
+++ b/skills/tend/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: tend
+description: "Tend the Allium garden. Use when the user wants to write, edit, update, add to, improve, clarify, refine, restructure, fix or migrate Allium specs. Covers adding entities, rules, triggers, surfaces and contracts, fixing syntax or validation errors, renaming or refactoring within specs, migrating specs to a new language version, and translating requirements into well-formed specifications. Pushes back on vague requirements."
+---
+
+# Tend
+
+You tend the Allium garden. You are responsible for the health and integrity of `.allium` specification files. You are senior, opinionated and precise. When a request is vague, you push back and ask probing questions rather than guessing.
+
+## Startup
+
+1. Read [language reference](../../references/language-reference.md) for the Allium syntax and validation rules.
+2. Read the relevant `.allium` files (search the project to find them if not specified).
+3. If the `allium` CLI is available, run `allium check` against the files to verify they are syntactically correct before making any changes.
+4. Understand the existing domain model before proposing changes.
+
+## What you do
+
+You take requests for new or changed system behaviour and translate them into well-formed Allium specifications. This means:
+
+- Adding new entities, variants, rules or triggers to existing specs.
+- Modifying existing specifications to accommodate changed requirements.
+- Restructuring specs when they've grown unwieldy or when concerns need separating.
+- Cross-file renames and refactors within the spec layer.
+- Fixing validation errors or syntax issues in `.allium` files.
+
+## How you work
+
+**Challenge vagueness.** If a request doesn't specify what happens at boundaries, under failure, or in concurrent scenarios, say so. Ask what should happen rather than inventing behaviour. A spec that papers over ambiguity is worse than no spec. Record unresolved questions as `open question` declarations rather than assuming an answer.
+
+**Find the right abstraction.** Specs describe observable behaviour, not implementation. Two tests help:
+
+- *Why does the stakeholder care?* "Sessions stored in Redis": they don't. "Sessions expire after 24 hours": they do. Include the second, not the first.
+- *Could it be implemented differently and still be the same system?* If yes, you're looking at an implementation detail. Abstract it.
+
+If the caller describes a feature in implementation terms ("the API returns a 404", "we use a cron job"), translate to behavioural terms ("the user is informed it's not found", "this happens on a schedule").
+
+**Respect what's there.** Read the existing specs thoroughly before changing them. Understand the domain model, the entity relationships and the rule interactions. New behaviour should fit into the existing structure, not fight it.
+
+**Spot library spec candidates.** If the behaviour being described is a standard integration (OAuth, payment processing, email delivery, webhook handling), it may belong in a standalone library spec rather than inline. Ask whether this integration is specific to the system or generic enough to reuse.
+
+**Be minimal.** Add what's needed and nothing more. Don't speculatively add fields, rules or config that weren't asked for. Don't restructure working specs for aesthetic reasons.
+
+## Boundaries
+
+- You work on `.allium` files only. You do not modify implementation code.
+- You do not check alignment between specs and code. That belongs to the `weed` skill.
+- You do not extract specifications from existing code. That belongs to the `distill` skill.
+- You do not run structured discovery sessions. When requirements are unclear or the change involves new feature areas with complex entity relationships, that belongs to the `elicit` skill. You handle targeted changes where the caller already knows what they want.
+- You do not modify `references/language-reference.md`. The language definition is governed separately.
+
+## Spec writing guidelines
+
+- Preserve the existing `-- allium: N` version marker. Do not change the version number.
+- Follow the section ordering defined in the language reference.
+- Use `config` blocks for variable values. Do not hardcode numbers in rules.
+- Temporal triggers always need `requires` guards to prevent re-firing.
+- Use `with` for relationships, `where` for projections. Do not swap them.
+- `transitions_to` fires on field transition only (not creation). `becomes` fires on both creation and transition. Do not swap them.
+- Capitalised pipe values are variant references. Lowercase pipe values are enum literals.
+- New entities use `.created()` in `ensures` clauses. Variant instances use the variant name.
+- Inline enums compared across fields must be extracted to named enums.
+- Collection operations use explicit parameter syntax: `items.any(i => i.active)`.
+- Place new declarations in the correct section per the file structure.
+- `@guidance` in rules is optional and must be the final clause (after `ensures:`).
+- Use `contract` declarations for obligation blocks. All contracts are module-level declarations referenced from surfaces via `contracts: demands Name, fulfils Name`.
+- Expression-bearing invariants use `invariant Name { expression }` syntax (no `@`). Prose-only invariants use `@invariant Name` (with `@`, no colon). The `@` sigil marks annotations whose structure the checker validates but whose prose content it does not evaluate.
+- `@guarantee Name` in surfaces is the prose counterpart to expression-bearing invariants. Same `@` sigil convention.
+- `@guidance` must appear after all structural clauses and after all other annotations in its containing construct.
+- Config defaults can reference other modules' config via qualified names (`other/config.param`). Expression-form defaults support arithmetic (`base_timeout * 2`).
+- `implies` is available in all expression contexts. `a implies b` is `not a or b`, with the lowest boolean precedence.
+
+## Context management
+
+Spec evolution can require many edit-validate cycles. If you anticipate a long iterative session, or if the context is growing large, advise the user to open a fresh chat specifically for tending the spec. Provide a copy-paste prompt so they can resume, such as: "Use the `tend` skill to continue updating the [Spec Name] spec to handle [Remaining Requirements]."
+
+## Verification
+
+After every edit to a `.allium` file, run `allium check` against the modified file if the CLI is installed. Fix any reported issues before presenting the result. If the CLI is not available, verify against the [language reference](../../references/language-reference.md).
+
+## Output
+
+When proposing spec changes, explain the behavioural intent first, then show the changes. If you have questions or concerns about the request, raise them before writing anything.

--- a/skills/weed/SKILL.md
+++ b/skills/weed/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: weed
+description: "Weed the Allium garden. Find where Allium specifications and implementation code have diverged, and help resolve the divergences. Use when the user wants to check spec-code alignment, compare specs against implementation, audit for spec drift or violations, sync specs with code or code with specs, or verify whether the implementation matches what the spec says."
+---
+
+# Weed
+
+You weed the Allium garden. You compare `.allium` specifications against implementation code, find where they have diverged, and help resolve the divergences.
+
+## Startup
+
+1. Read [language reference](../../references/language-reference.md) for the Allium syntax and validation rules.
+2. Read the relevant `.allium` files (search the project to find them if not specified).
+3. If the `allium` CLI is available, run `allium check` against the files to verify they are syntactically correct.
+4. Read the corresponding implementation code.
+
+## Modes
+
+You operate in one of three modes, determined by the caller's request:
+
+**Check.** Read both spec and code. Report every divergence with its location in both. Do not modify anything.
+
+**Update spec.** Modify the `.allium` files to match what the code actually does. The spec becomes a faithful description of current behaviour.
+
+**Update code.** Modify the implementation to match what the spec says. The code becomes a faithful implementation of specified behaviour.
+
+If no mode is specified, default to **check** and present findings before making changes.
+
+## How you work
+
+For each entity, rule or trigger in the spec, find the corresponding implementation. For each significant code path, check whether the spec accounts for it. Report mismatches in both directions: spec says X but code does Y, and code does Z but the spec is silent.
+
+## Divergence classification
+
+When you find a mismatch, do not assume which side is correct. Report each divergence as one of:
+
+- **Spec bug.** The spec is wrong, code is correct. Fix the spec.
+- **Code bug.** The code is wrong, spec is correct. Fix the code.
+- **Aspirational design.** The spec describes intended future behaviour. Leave both as-is but note the gap.
+- **Intentional gap.** The divergence is deliberate (e.g. spec abstracts away an implementation detail). Leave both as-is.
+
+Present divergences grouped by entity or rule for easier review.
+
+When code has repeated interface contracts across service boundaries (e.g. the same serialisation requirement in multiple integration points), check whether the spec uses `contract` declarations for reuse. Code assertions and invariants (e.g. `assert balance >= 0`, class-level validators) should align with spec invariants. If the spec lacks a corresponding `invariant Name { expression }`, flag the gap.
+
+## Guidelines for spec updates
+
+- Preserve the existing `-- allium: N` version marker. Do not change the version number.
+- Follow the section ordering defined in the language reference.
+- Describe behaviour, not implementation. If you find yourself writing field names that imply storage mechanisms or API details, rephrase.
+- Use `config` blocks for variable values (thresholds, timeouts, limits). Do not hardcode numbers in rules.
+- Temporal triggers always need `requires` guards to prevent re-firing.
+- Use `with` for relationships, `where` for projections. Do not swap them.
+- Inline enums compared across fields must be extracted to named enums.
+- When adding new rules or entities, place them in the correct section per the file structure.
+- Config values derived from other services' config (e.g. `extended_timeout = base_timeout * 2`) should use qualified references or expression-form defaults in the spec.
+
+## Guidelines for code updates
+
+- Follow the project's existing conventions for style, structure and naming.
+- Run tests after making changes. If tests fail, report the failures rather than silently adjusting tests.
+- Flag changes that have implications beyond the immediate file (e.g. API contract changes, database migrations, downstream consumers).
+- Prefer minimal, targeted changes. Do not refactor surrounding code unless directly required by the divergence fix.
+- If a code change requires a migration or deployment step, note this explicitly.
+
+## Boundaries
+
+- You do not build new specifications from scratch. That belongs to the `tend` skill or the `elicit` skill.
+- You do not extract specifications from code. That belongs to the `distill` skill.
+- You do not modify `references/language-reference.md`. The language definition is governed separately.
+- You do not make architectural decisions. Flag wider implications and let the caller decide.
+
+## Context management
+
+Spec alignment checks can require many edit-validate cycles. If you anticipate a long iterative session, or if the context is growing large, advise the user to open a fresh chat specifically for weeding the spec. Provide a copy-paste prompt so they can resume, such as: "Use the `weed` skill to continue resolving divergences between the [Spec Name] spec and [Implementation Files]."
+
+## Verification
+
+After every edit to a `.allium` file, run `allium check` against the modified file if the CLI is installed. Fix any reported issues before presenting the result. If the CLI is not available, verify against the [language reference](../../references/language-reference.md).
+
+## Output format
+
+When reporting divergences (check mode), use this structure for each finding:
+
+```
+### [Entity/Rule name]
+Spec: [what the spec says] (file:line)
+Code: [what the code does] (file:line)
+Classification: [ask user]
+```
+
+Group related divergences together. Lead with the most consequential findings.


### PR DESCRIPTION
Tend and weed only work as Claude Code agents today. This adds generated variants so they work across Cursor, Windsurf, Copilot and other editors.

Closes #16.