### PR TITLE
Wire allium-lsp in plugin.json for live .allium diagnostics (#39)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -21,5 +21,13 @@
   "agents": [
     "./agents/tend.md",
     "./agents/weed.md"
-  ]
+  ],
+  "lspServers": {
+    "allium": {
+      "command": "allium-lsp",
+      "extensionToLanguage": {
+        ".allium": "allium"
+      }
+    }
+  }
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -25,6 +25,7 @@
   "lspServers": {
     "allium": {
       "command": "allium-lsp",
+      "args": ["--stdio"],
       "extensionToLanguage": {
         ".allium": "allium"
       }

--- a/README.md
+++ b/README.md
@@ -230,6 +230,14 @@ The developer never mentioned invoicing or payment method capture. The Allium di
 
 When the CLI is installed, `.allium` files are validated automatically after every write or edit. Diagnostics appear inline and the model fixes issues in the same turn.
 
+**Live diagnostics in Claude Code.** The Claude Code plugin also wires the `allium-lsp` language server, so Claude receives checker errors, go-to-definition and hover for `.allium` files immediately after each edit, without a separate `allium check` invocation. The language server is **not bundled** with the plugin — install it separately and make sure `allium-lsp` is on your `PATH`:
+
+```
+npm install -g allium-lsp
+```
+
+See the [allium-tools repo](https://github.com/juxt/allium-tools) for other install paths.
+
 ## Language governance
 
 Every change to Allium is debated by a [nine-member review panel](https://github.com/juxt/allium/blob/proposals/TEAM.md) before adoption. Each panellist represents a distinct design priority: simplicity, machine reasoning, composability, readability, formal rigour, domain modelling, developer experience, creative ambition and backward compatibility. The panel exists to surface tensions that any single perspective would miss.

--- a/README.md
+++ b/README.md
@@ -230,13 +230,7 @@ The developer never mentioned invoicing or payment method capture. The Allium di
 
 When the CLI is installed, `.allium` files are validated automatically after every write or edit. Diagnostics appear inline and the model fixes issues in the same turn.
 
-**Live diagnostics in Claude Code.** The Claude Code plugin also wires the `allium-lsp` language server, so Claude receives checker errors, go-to-definition and hover for `.allium` files immediately after each edit, without a separate `allium check` invocation. The language server is **not bundled** with the plugin — install it separately and make sure `allium-lsp` is on your `PATH`:
-
-```
-npm install -g allium-lsp
-```
-
-See the [allium-tools repo](https://github.com/juxt/allium-tools) for other install paths.
+**Live diagnostics in Claude Code.** The Claude Code plugin also wires the `allium-lsp` language server, so Claude receives checker errors, go-to-definition and hover for `.allium` files immediately after each edit, without a separate `allium check` invocation. The language server is **not bundled** with the plugin — install the `allium-lsp` server from the [allium-tools repo](https://github.com/juxt/allium-tools) and make sure the `allium-lsp` binary is on your `PATH`. If it isn't found, Claude Code reports `Executable not found in $PATH` in the `/plugin` Errors tab and falls back to CLI checking.
 
 ## Language governance
 


### PR DESCRIPTION
## What

Wires the `allium-lsp` language server into the Claude Code plugin so Claude receives live diagnostics, go-to-definition and hover for `.allium` files immediately after each edit — without a separate `allium check` run. Closes #39.

### Changes

1. **`.claude-plugin/plugin.json`** — add the `lspServers` entry (exact config from the issue):
   ```json
   "lspServers": {
     "allium": {
       "command": "allium-lsp",
       "extensionToLanguage": { ".allium": "allium" }
     }
   }
   ```
2. **`README.md`** — note in the Verification section that `allium-lsp` is **not bundled** and must be installed separately and be on `PATH`, with a pointer to allium-tools.

### Acceptance criteria (#39)

- [x] `plugin.json` includes an `lspServers` entry wiring `allium-lsp` to `.allium`
- [x] README notes `allium-lsp` must be installed separately
- [ ] *Cannot verify here* that diagnostics actually flow — that requires the `allium-lsp` binary on PATH and a Claude Code session; the binary work lives in juxt/allium-tools and is out of scope for this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)