### PR TITLE
Bump plugin version to 3.4.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "allium",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Velocity through clarity.",
   "author": {
     "name": "JUXT",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "allium",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Velocity through clarity.",
   "author": {
     "name": "JUXT",


### PR DESCRIPTION
## What

Minor version bump **3.3.0 → 3.4.0** for both plugin manifests (`.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`).

## Why

Since `v3.3.0` the plugin gained new backwards-compatible features:
- **LSP server wiring** via `lspServers` (#48)
- **Codex support** + `.codex-plugin/plugin.json` manifest (#41)

Additive, non-breaking → minor bump per semver. (Docs-only changes like #38/#49 ride along.)

## Note
The `juxt/claude-plugins` marketplace vendors this plugin pinned by ref; once this is merged (and ideally tagged), re-vendoring there — bump `scripts/allium-ref.txt` and run `scripts/sync-allium.sh` — will carry 3.4.0 to the marketplace copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)