### PR TITLE
Bump plugin version to 3.5.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "allium",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Velocity through clarity.",
   "author": {
     "name": "JUXT",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "allium",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Velocity through clarity.",
   "author": {
     "name": "JUXT",


### PR DESCRIPTION
Minor version bump `3.4.0 → 3.5.0` in both plugin manifests (`.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`).

Covers the CLI install notice shipped in #51 — new backward-compatible behaviour (first-run install prompt, model-driven install offer, "shown once" marker files), with no breaking changes, so a **minor** bump per semver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)