### PR TITLE
Bump plugin version to 3.8.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "allium",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Velocity through clarity.",
   "author": {
     "name": "JUXT",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "allium",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Velocity through clarity.",
   "author": {
     "name": "JUXT",


### PR DESCRIPTION
Minor bump for the obligation reconciliation step added to the propagate skill in #56: new backward-compatible behaviour, no breaking changes. Bumps both `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6FTVnDrei6nNse624pG3w