### PR TITLE
Point homepage at allium-lang.org

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "JUXT",
     "url": "https://juxt.pro"
   },
-  "homepage": "https://juxt.github.io/allium/",
+  "homepage": "https://allium-lang.org/",
   "repository": "https://github.com/juxt/allium",
   "license": "MIT",
   "keywords": ["specification", "behaviour", "behavior", "domain-modelling", "BDD", "property-based-testing", "generative-tests"],

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "JUXT",
     "url": "https://juxt.pro"
   },
-  "homepage": "https://juxt.github.io/allium/",
+  "homepage": "https://allium-lang.org/",
   "repository": "https://github.com/juxt/allium",
   "license": "MIT",
   "keywords": [
@@ -30,7 +30,7 @@
       "Write",
       "Interactive"
     ],
-    "websiteURL": "https://juxt.github.io/allium/",
+    "websiteURL": "https://allium-lang.org/",
     "defaultPrompt": [
       "Draft an Allium spec for this feature.",
       "Review this .allium spec for gaps.",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ---
 
-Feed your AI something healthier than Markdown. [juxt.github.io/allium](https://juxt.github.io/allium/)
+Feed your AI something healthier than Markdown. [allium-lang.org](https://allium-lang.org/)
 
 ## What this is
 


### PR DESCRIPTION
The canonical site moved from `juxt.github.io/allium` to [allium-lang.org](https://allium-lang.org/). Updates the README link and the `homepage`/`websiteURL` fields in both plugin manifests (4 occurrences). Metadata only — no version bump; the new metadata ships with the next real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6FTVnDrei6nNse624pG3w