### PR TITLE
Bump plugin version to 3.9.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "allium",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "Velocity through clarity.",
   "author": {
     "name": "JUXT",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "allium",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "Velocity through clarity.",
   "author": {
     "name": "JUXT",


### PR DESCRIPTION
Release 3.9.0. Ships the dual-entry agent refactor (#63): skills are the single source of truth, Claude Code agents are thin preload shells, distill and propagate added as agents for loop isolation. Backward-compatible feature addition.