### PR TITLE
Bump plugin version to 3.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "allium",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "Velocity through clarity.",
   "author": {
     "name": "JUXT",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "allium",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "Velocity through clarity.",
   "author": {
     "name": "JUXT",


### PR DESCRIPTION
Minor bump for #65 (per-phase sub-agent delegation is now the default in the loop): backward-compatible behaviour change, so 3.9.0 → 3.10.0. Leaves 4.0 free.