### PR TITLE
Harden loop trace writes against symlinks

### DIFF
--- a/hooks/loop-trace.mjs
+++ b/hooks/loop-trace.mjs
@@ -16,11 +16,14 @@
 // blocks a call (always exits 0), and swallows its own errors.
 
 import {
+  closeSync,
+  constants,
   existsSync,
+  lstatSync,
+  openSync,
   readFileSync,
-  writeFileSync,
-  appendFileSync,
   realpathSync,
+  writeFileSync,
 } from "fs";
 import path from "path";
 
@@ -75,6 +78,12 @@ if (!projectRoot) process.exit(0);
 // Only trace while a loop is running; otherwise this is an unrelated subagent.
 const loopDir = path.join(projectRoot, ".allium-loop");
 if (!existsSync(loopDir)) process.exit(0);
+try {
+  const stat = lstatSync(loopDir);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) process.exit(0);
+} catch {
+  process.exit(0);
+}
 
 const pendingPath = path.join(loopDir, ".timing-pending.json");
 const timingsPath = path.join(loopDir, "timings.jsonl");
@@ -82,18 +91,36 @@ const now = Date.now();
 
 function readPending() {
   try {
+    const stat = lstatSync(pendingPath);
+    if (!stat.isFile() || stat.isSymbolicLink()) return { byId: {}, fifo: [] };
     const p = JSON.parse(readFileSync(pendingPath, "utf-8"));
     return { byId: p.byId ?? {}, fifo: Array.isArray(p.fifo) ? p.fifo : [] };
   } catch {
     return { byId: {}, fifo: [] };
   }
 }
-function writePending(p) {
+function writeWithoutFollowingSymlinks(filePath, data, append = false) {
+  let fd;
   try {
-    writeFileSync(pendingPath, JSON.stringify(p));
+    const noFollow = constants.O_NOFOLLOW ?? 0;
+    const mode = append ? constants.O_APPEND : constants.O_TRUNC;
+    fd = openSync(filePath, constants.O_WRONLY | constants.O_CREAT | mode | noFollow, 0o600);
+    writeFileSync(fd, data);
+    return true;
   } catch {
-    // best-effort
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        // best-effort
+      }
+    }
   }
+}
+function writePending(p) {
+  writeWithoutFollowingSymlinks(pendingPath, JSON.stringify(p));
 }
 
 if (event === "pre") {
@@ -122,10 +149,6 @@ if (rec) {
       agent: rec.agent,
       duration_ms: now - rec.start,
     }) + "\n";
-  try {
-    appendFileSync(timingsPath, line);
-  } catch {
-    // best-effort
-  }
+  writeWithoutFollowingSymlinks(timingsPath, line, true);
 }
 process.exit(0);

--- a/hooks/loop-trace.test.mjs
+++ b/hooks/loop-trace.test.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from "child_process";
-import { mkdtempSync, mkdirSync, readFileSync, existsSync, rmSync } from "fs";
+import { mkdtempSync, mkdirSync, readFileSync, existsSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import path from "path";
 import { tmpdir } from "os";
 
@@ -91,6 +91,42 @@ console.log("\n── loop-trace hook ──\n");
   } catch {
     assert("survives malformed input", false);
   }
+  rmSync(dir, { recursive: true, force: true });
+}
+
+// 6. A repository-controlled .allium-loop symlink must not redirect writes.
+{
+  const dir = newProject({ withLoopDir: false });
+  const outside = mkdtempSync(path.join(tmpdir(), "allium-timing-outside-"));
+  symlinkSync(outside, path.join(dir, ".allium-loop"));
+  const payload = { tool_use_id: "linked-dir", tool_name: "Task", tool_input: { subagent_type: "allium:weed" } };
+  runHook("pre", payload, dir);
+  assert("refuses a symlinked loop directory", !existsSync(path.join(outside, ".timing-pending.json")));
+  rmSync(dir, { recursive: true, force: true });
+  rmSync(outside, { recursive: true, force: true });
+}
+
+// 7. A symlinked pending-state file must not be read or overwritten.
+{
+  const dir = newProject({ withLoopDir: true });
+  const victim = path.join(dir, "victim-pending.txt");
+  writeFileSync(victim, "unchanged");
+  symlinkSync(victim, path.join(dir, ".allium-loop", ".timing-pending.json"));
+  runHook("pre", { tool_use_id: "linked-pending", tool_name: "Task", tool_input: { subagent_type: "allium:weed" } }, dir);
+  assert("refuses a symlinked pending-state file", readFileSync(victim, "utf-8") === "unchanged");
+  rmSync(dir, { recursive: true, force: true });
+}
+
+// 8. A symlinked timing log must not receive appended data.
+{
+  const dir = newProject({ withLoopDir: true });
+  const payload = { tool_use_id: "linked-log", tool_name: "Task", tool_input: { subagent_type: "allium:weed" } };
+  runHook("pre", payload, dir);
+  const victim = path.join(dir, "victim-timings.txt");
+  writeFileSync(victim, "unchanged");
+  symlinkSync(victim, path.join(dir, ".allium-loop", "timings.jsonl"));
+  runHook("post", payload, dir);
+  assert("refuses a symlinked timing log", readFileSync(victim, "utf-8") === "unchanged");
   rmSync(dir, { recursive: true, force: true });
 }
 


### PR DESCRIPTION
## Summary

- Reject a symlinked `.allium-loop` directory.
- Open the pending-state and timing-log files with `O_NOFOLLOW`.
- Add regression coverage for directory, pending-file, and timing-log symlinks.

## Why

A repository can contain a symlink at `.allium-loop/.timing-pending.json` or
`.allium-loop/timings.jsonl`. The hook previously followed those symlinks while
truncating or appending, allowing a repository-controlled path to redirect a
write to another file writable by the user.

The hook remains best-effort: unsafe paths are ignored instead of blocking an
agent call.

## Verification

- `node hooks/loop-trace.test.mjs`: 10 passed, 0 failed
- `node scripts/test-skills.mjs hooks`: 6 passed, 0 failed
- `node scripts/test-skills.mjs`: 188 passed, 0 failed, 7 live/API probes skipped
